### PR TITLE
Add note badges

### DIFF
--- a/apps/expo/src/app/(authenticated)/index.tsx
+++ b/apps/expo/src/app/(authenticated)/index.tsx
@@ -24,6 +24,7 @@ import Button from "~/components/button";
 import { NoteListItem, NoteListItemRightSwipeActions } from "~/components/note";
 import { deleteNoteById, getNotes, uploadRecording } from "~/utils/api";
 import { startRecording, stopRecording } from "~/utils/audio";
+import Badge from "~/components/badge";
 
 /**
  * Home page for authenticated users
@@ -97,8 +98,13 @@ export default function HomePage() {
           />
           <Avatar />
         </View>
+        {/* Badges */}
+        <View className="w-full flex flex-row items-center justify-start gap-2 p-4">
+          <Badge text="Notes" />
+          <Badge text="Digests" />
+        </View>
         {/* Content */}
-        <View className="flex max-h-[80vh] flex-grow flex-col items-start justify-start gap-2">
+        <View className="flex max-h-[70vh] flex-grow flex-col items-start justify-start gap-2">
           {notesLoading && (
             <View className="flex h-[50vh] w-full items-center justify-center">
               <Loader2Icon size={48} className="animate-spin text-gray-400" />

--- a/apps/expo/src/app/(authenticated)/note/[id].tsx
+++ b/apps/expo/src/app/(authenticated)/note/[id].tsx
@@ -12,6 +12,8 @@ import type { Note } from "@brain2/db/client";
 
 import Avatar from "~/components/avatar";
 import { getNoteById } from "~/utils/api";
+import { NOTE_BADGE_COLORS, getDateStringFromSpan } from "~/components/note";
+import Badge from "~/components/badge";
 
 interface NoteViewProps {
   note: Note;
@@ -27,14 +29,19 @@ function NoteView({ note, loading, refetch }: NoteViewProps) {
     setRefreshing(false);
   }, [refetch]);
 
-  const formattedDate = DateTime.fromISO(note.createdAt.toString()).toFormat(
-    "ccc dd/MM/yyyy HH:mm a",
-  );
+  const date = DateTime.fromISO(note.createdAt.toString());
+  const dateString = getDateStringFromSpan(date, note.digestSpan);
 
   return (
     <View className="mb-12 flex flex-col gap-2">
       <Text className="text-3xl">{note.title}</Text>
-      <Text className="text-sm font-light text-gray-500">{formattedDate}</Text>
+      <Text className="text-sm font-light text-gray-500">{dateString}</Text>
+      {note.digestSpan !== "SINGLE" ? (
+        <Badge
+          text={note.digestSpan}
+          className={NOTE_BADGE_COLORS[note.digestSpan]}
+        />
+      ) : null}
       <ScrollView
         className="flex-grow"
         overScrollMode="always"

--- a/apps/expo/src/components/badge.tsx
+++ b/apps/expo/src/components/badge.tsx
@@ -1,0 +1,22 @@
+import { Text, View } from "react-native";
+import clsx from "clsx";
+
+interface Props {
+  text: string;
+  className?: string;
+}
+
+export default function Badge({ text, className }: Props) {
+  return (
+    <View className="flex flex-row items-start">
+      <View
+        className={clsx(
+          "rounded-full border border-black bg-gray-200 px-4 py-2",
+          className,
+        )}
+      >
+        <Text>{text}</Text>
+      </View>
+    </View>
+  );
+}

--- a/apps/expo/src/components/note.tsx
+++ b/apps/expo/src/components/note.tsx
@@ -3,7 +3,9 @@ import { Text, View } from "react-native";
 import { TrashIcon } from "lucide-react-native";
 import { DateTime } from "luxon";
 
-import type { Note } from "@brain2/db/client";
+import type { Note, NoteDigestSpan } from "@brain2/db/client";
+
+import Badge from "./badge";
 
 interface NoteListItemProps {
   note: Note;
@@ -20,18 +22,42 @@ export function NoteListItemRightSwipeActions() {
   );
 }
 
+export function getDateStringFromSpan(date: DateTime, span: NoteDigestSpan) {
+  if (span === "SINGLE") {
+    return date.toFormat("ccc dd/MM/yyyy HH:mm:ss");
+  } else if (span === "DAY") {
+    return date.toFormat("ccc dd/MM/yyyy");
+  } else if (span === "WEEK") {
+    const endDate = date.plus({ days: 6 });
+    return `${date.toFormat("ccc dd/MM/yyyy")} - ${endDate.toFormat(
+      "ccc dd/MM/yyyy",
+    )}`;
+  }
+}
+
+export const NOTE_BADGE_COLORS = {
+  SINGLE: "bg-gray-200",
+  DAY: "bg-yellow-100",
+  WEEK: "bg-cyan-100",
+};
+
 /**
  * A list item representing a note
  */
 export function NoteListItem({ note }: NoteListItemProps) {
-  const formattedDate = DateTime.fromISO(note.createdAt.toString()).toFormat(
-    "ccc dd/MM/yyyy HH:mm:ss",
-  );
+  const date = DateTime.fromISO(note.createdAt.toString());
+  const dateString = getDateStringFromSpan(date, note.digestSpan);
 
   return (
     <View className="flex flex-col gap-2 bg-white px-4 py-2">
       <Text className="text-2xl font-semibold">{note.title}</Text>
-      <Text className="text-md font-light text-gray-700">{formattedDate}</Text>
+      <Text className="text-md font-light text-gray-700">{dateString}</Text>
+      {note.digestSpan !== "SINGLE" ? (
+        <Badge
+          text={note.digestSpan}
+          className={NOTE_BADGE_COLORS[note.digestSpan]}
+        />
+      ) : null}
     </View>
   );
 }


### PR DESCRIPTION
Adds badges for note digests, indicating whether they are daily or weekly digests, as well as changing the displayed formatted date to better reflect the coverage of a note digest.

## Screenshots
<img width="200" alt="image" src="https://github.com/gramliu/brain2/assets/24856195/7d4349fe-d6ec-447d-b578-68dcbd14e223">

<img width="200" alt="image" src="https://github.com/gramliu/brain2/assets/24856195/843d4ab1-faa8-416f-b0f9-4ac6267d0b95">
