### PR TITLE
Remove redundant ai env vars

### DIFF
--- a/apps/nextjs/src/env.js
+++ b/apps/nextjs/src/env.js
@@ -11,6 +11,7 @@ export const env = createEnv({
       .string()
       .optional()
       .transform((v) => (v ? `https://${v}` : undefined)),
+    VERCEL_PROD_URL: z.string().optional(),
     PORT: z.coerce.number().default(3000),
   },
   /**
@@ -40,7 +41,9 @@ export const env = createEnv({
    * Destructure all variables from `process.env` to make sure they aren't tree-shaken away.
    */
   runtimeEnv: {
+    VERCEL_ENV: process.env.VERCEL_ENV,
     VERCEL_URL: process.env.VERCEL_URL,
+    VERCEL_PROD_URL: process.env.VERCEL_ENV === "production" ? "brain2-psi.vercel.app" : process.env.VERCEL_URL,
     PORT: process.env.PORT,
     DATABASE_URL: process.env.DATABASE_URL,
     AWS_S3_REGION: process.env.AWS_S3_REGION,

--- a/apps/nextjs/src/util/messenger/initiateLogin.ts
+++ b/apps/nextjs/src/util/messenger/initiateLogin.ts
@@ -1,8 +1,7 @@
 import axios from "axios";
 
-import { env } from "@brain2/ai";
-
 import type { InitiateLoginRequest } from "./types/initiateLoginRequest";
+import { env } from "~/env";
 
 export async function initiateLogin(senderPSID: string): Promise<void> {
   const loginMsg: InitiateLoginRequest = {

--- a/apps/nextjs/src/util/messenger/initiateLogin.ts
+++ b/apps/nextjs/src/util/messenger/initiateLogin.ts
@@ -15,7 +15,7 @@ export async function initiateLogin(senderPSID: string): Promise<void> {
           buttons: [
             {
               type: "web_url",
-              url: `${env.VERCEL_URL}/messenger-auth?messengerPSID=${senderPSID}`,
+              url: `${env.VERCEL_PROD_URL}/messenger-auth?messengerPSID=${senderPSID}`,
               title: "Log In",
               webview_height_ratio: "full",
             },

--- a/apps/nextjs/src/util/messenger/sendMessage.ts
+++ b/apps/nextjs/src/util/messenger/sendMessage.ts
@@ -1,9 +1,8 @@
 import axios from "axios";
 
-import { env } from "@brain2/ai";
-
 import type { SendMessageRequest } from "./types/sendMessageRequest";
 import { DEFAULT_MESSENGER_QUICK_REPLIES } from "./constants";
+import { env } from "~/env";
 
 // Send a message by calling the messenger API.
 export async function sendMessage(

--- a/apps/nextjs/src/util/messenger/sendMessengerAction.ts
+++ b/apps/nextjs/src/util/messenger/sendMessengerAction.ts
@@ -1,9 +1,8 @@
 import axios from "axios";
 
-import { env } from "@brain2/ai";
-
 import type { SenderAction } from "./types/senderAction";
 import type { SenderActionRequest } from "./types/senderActionRequest";
+import { env } from "~/env";
 
 // Mark a message as seen or turn the typing animation on
 export async function sendMessengerAction(

--- a/packages/ai/src/env.ts
+++ b/packages/ai/src/env.ts
@@ -13,10 +13,6 @@ export const env = createEnv({
     // Momento LLM response caching
     MOMENTO_API_KEY: z.string(),
     MOMENTO_CACHE_NAME: z.string(),
-    MESSENGER_VERIFY_TOKEN: z.string(),
-    MESSENGER_ACCESS_TOKEN: z.string(),
-    MESSENGER_API_URL: z.string(),
-    VERCEL_URL: z.string(),
   },
   client: {},
   runtimeEnv: process.env,


### PR DESCRIPTION
This removes redundant environment variables declared in the `@brain2/ai` package. These are already specified in the env in `@brain2/nextjs`, so I'm removing them from there. Additionally, I'm replacing the env imports to point to the nextjs one.