### PR TITLE
Add VERCEL_PROD_URL env var

### DIFF
--- a/apps/nextjs/src/env.js
+++ b/apps/nextjs/src/env.js
@@ -11,6 +11,7 @@ export const env = createEnv({
       .string()
       .optional()
       .transform((v) => (v ? `https://${v}` : undefined)),
+    VERCEL_PROD_URL: z.string().optional(),
     PORT: z.coerce.number().default(3000),
   },
   /**
@@ -40,7 +41,9 @@ export const env = createEnv({
    * Destructure all variables from `process.env` to make sure they aren't tree-shaken away.
    */
   runtimeEnv: {
+    VERCEL_ENV: process.env.VERCEL_ENV,
     VERCEL_URL: process.env.VERCEL_URL,
+    VERCEL_PROD_URL: process.env.VERCEL_ENV === "production" ? "brain2-psi.vercel.app" : process.env.VERCEL_URL,
     PORT: process.env.PORT,
     DATABASE_URL: process.env.DATABASE_URL,
     AWS_S3_REGION: process.env.AWS_S3_REGION,

--- a/apps/nextjs/src/util/messenger/initiateLogin.ts
+++ b/apps/nextjs/src/util/messenger/initiateLogin.ts
@@ -15,7 +15,7 @@ export async function initiateLogin(senderPSID: string): Promise<void> {
           buttons: [
             {
               type: "web_url",
-              url: `${env.VERCEL_URL}/messenger-auth?messengerPSID=${senderPSID}`,
+              url: `${env.VERCEL_PROD_URL}/messenger-auth?messengerPSID=${senderPSID}`,
               title: "Log In",
               webview_height_ratio: "full",
             },


### PR DESCRIPTION
This points messenger logins on production builds to the production URL rather than the deployment-specific URL. This addresses the issue shown below, where even on production builds, the authentication redirects to the deployment-specific URL.
 
![image](https://github.com/gramliu/brain2/assets/24856195/ee83c846-1e3d-4322-b9c5-e56e99064269)
