### PR TITLE
Fix batch digest timing out

### DIFF
--- a/packages/lib/src/queue/functions/batchDigest/handler.ts
+++ b/packages/lib/src/queue/functions/batchDigest/handler.ts
@@ -22,14 +22,14 @@ export const handler = inngestEdgeClient.createFunction(
     const { span, date } = argSchema.parse(event.data);
     console.log(`Digesting notes for span ${span} and date ${date}`);
 
-    const startDate = DateTime.fromISO(date);
-    let endDate = startDate;
+    const endDate = DateTime.fromISO(date);
+    let startDate = endDate;
 
     // Compute end date based on span
     if (span === "DAY") {
-      endDate = startDate.plus({ days: 1 });
+      startDate = endDate.minus({ days: 1 });
     } else if (span === "WEEK") {
-      endDate = startDate.plus({ days: 7 });
+      startDate = endDate.minus({ days: 7 });
     }
 
     if (startDate == null || endDate == null) {

--- a/packages/lib/src/queue/functions/batchDigest/handler.ts
+++ b/packages/lib/src/queue/functions/batchDigest/handler.ts
@@ -36,6 +36,8 @@ export const handler = inngestEdgeClient.createFunction(
       throw new Error("Invalid date: " + date);
     }
 
+    console.log("Range", startDate.toISO(), endDate.toISO()!);
+
     const notes = (await prisma.note.aggregateRaw({
       pipeline: [
         {


### PR DESCRIPTION
This replaces the prisma aggregation with an in-memory group. For some reason, aggregations with Prisma Accelerate run really slowly and exceed Accelerate's timeout of 10s. Since Vercel's edge runtime has a more generous time limit of 15mins, we can leverage that instead.