### PR TITLE
Add backend support for version history

### DIFF
--- a/apps/expo/src/app/(authenticated)/index.tsx
+++ b/apps/expo/src/app/(authenticated)/index.tsx
@@ -20,6 +20,7 @@ import { DateTime } from "luxon";
 
 import type { Note, NoteDigestSpan } from "@brain2/db/client";
 
+import type { PopulatedNote } from "~/components/note";
 import Badge from "~/components/badge";
 import Button from "~/components/button";
 import { NoteCard, NoteListItemRightSwipeActions } from "~/components/note";
@@ -59,13 +60,20 @@ export default function HomePage() {
       await queryClient.cancelQueries({ queryKey: ["notes"] });
 
       const date = DateTime.now().toJSDate();
-      const staleNotes: Note[] = queryClient.getQueryData(["notes"])!;
-      const dummyNote: Note = {
-        id: "note_optimistic_placeholder",
+      const staleNotes: PopulatedNote[] = queryClient.getQueryData(["notes"])!;
+      const dummyNote: PopulatedNote = {
+        id: "note-id",
         owner: userId!,
-        title: "New Recording (Processing...)",
-        content: "New Recording (Processing...)",
         digestSpan: "SINGLE",
+        revisionId: "note-revision-id",
+        revision: {
+          id: "note-revision-id",
+          noteId: "note-id",
+          title: "New Recording (Processing...)",
+          content: "New Recording (Processing...)",
+          createdAt: date,
+          updatedAt: date,
+        },
         childrenIds: [],
         parentIds: [],
         active: false,

--- a/apps/expo/src/app/(authenticated)/note/[id].tsx
+++ b/apps/expo/src/app/(authenticated)/note/[id].tsx
@@ -1,16 +1,3 @@
-import { useAuth } from "@clerk/clerk-expo";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Stack, useLocalSearchParams } from "expo-router";
-import {
-  HistoryIcon,
-  Loader2Icon,
-  MoreHorizontalIcon,
-  PencilIcon,
-  RefreshCwIcon,
-  SaveIcon,
-  Share2Icon,
-} from "lucide-react-native";
-import { DateTime } from "luxon";
 import { useCallback, useEffect, useState } from "react";
 import {
   Pressable,
@@ -23,9 +10,21 @@ import {
 import { RefreshControl } from "react-native-gesture-handler";
 import Markdown from "react-native-markdown-display";
 import { Menu } from "react-native-paper";
+import { Stack, useLocalSearchParams } from "expo-router";
+import { useAuth } from "@clerk/clerk-expo";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  HistoryIcon,
+  Loader2Icon,
+  MoreHorizontalIcon,
+  PencilIcon,
+  RefreshCwIcon,
+  SaveIcon,
+  Share2Icon,
+} from "lucide-react-native";
+import { DateTime } from "luxon";
 
-import type { Note } from "@brain2/db/client";
-
+import type { PopulatedNote } from "~/components/note";
 import { EditableText } from "~/components/editableText";
 import { getNoteById, updateNote } from "~/utils/api";
 
@@ -35,7 +34,7 @@ interface NoteUpdateParams {
 }
 
 interface NoteViewProps {
-  note: Note;
+  note: PopulatedNote;
   loading: boolean;
   editMode: boolean;
   refetch: () => Promise<unknown>;
@@ -61,11 +60,12 @@ function NoteView({
   const timeString = date.toFormat("hh:mm a");
 
   const [edited, setEdited] = useState(false);
-  const [title, setTitle] = useState(note.title);
-  const [content, setContent] = useState(note.content);
+  const [title, setTitle] = useState(note.revision.title);
+  const [content, setContent] = useState(note.revision.content);
 
   useEffect(() => {
-    const changeDetected = note.title != title || note.content != content;
+    const changeDetected =
+      note.revision.title != title || note.revision.content != content;
     if (!editMode && edited && changeDetected) {
       // Save changes
       updateNote({ title, content });
@@ -80,7 +80,7 @@ function NoteView({
     <View className="mb-12 flex flex-col gap-2">
       <EditableText
         editable={editMode}
-        text={note.title}
+        text={note.revision.title}
         className="text-3xl"
         onSave={async (newTitle) => {
           setTitle(newTitle);
@@ -105,7 +105,7 @@ function NoteView({
       >
         <EditableText
           editable={editMode}
-          text={note.content}
+          text={note.revision.content}
           TextComponent={Markdown}
           onSave={async (newContent) => {
             setContent(newContent);
@@ -203,7 +203,7 @@ export default function NotePage() {
                       )}
                       title="History"
                     />
-                    {(note && note.digestSpan !== "SINGLE") ? (
+                    {note && note.digestSpan !== "SINGLE" ? (
                       <Menu.Item
                         onPress={() => {}}
                         leadingIcon={() => (

--- a/apps/expo/src/components/note.tsx
+++ b/apps/expo/src/components/note.tsx
@@ -3,10 +3,12 @@ import { Text, View } from "react-native";
 import { TrashIcon } from "lucide-react-native";
 import { DateTime } from "luxon";
 
-import type { Note } from "@brain2/db/client";
+import type { Note, NoteRevision } from "@brain2/db/client";
+
+export type PopulatedNote = Note & { revision: NoteRevision };
 
 interface NoteCardProps {
-  note: Note;
+  note: PopulatedNote;
 }
 
 /**
@@ -36,7 +38,7 @@ export function NoteCard({ note }: NoteCardProps) {
   return (
     <View className="flex flex-col gap-2 px-4 py-2">
       <View className="flex flex-col gap-2 rounded-2xl border border-black bg-white p-4">
-        <Text className="text-lg font-semibold">{note.title}</Text>
+        <Text className="text-lg font-semibold">{note.revision.title}</Text>
         <View className="flex flex-col gap-1">
           <Text className="text-md font-light text-gray-700">{dateString}</Text>
           {note.digestSpan == "SINGLE" ? (

--- a/apps/expo/src/utils/api.tsx
+++ b/apps/expo/src/utils/api.tsx
@@ -5,6 +5,8 @@ import axios from "axios";
 
 import type { Note } from "@brain2/db/client";
 
+import type { PopulatedNote } from "~/components/note";
+
 /**
  * Extend this function when going to production by
  * setting the baseUrl to your production API URL.
@@ -123,7 +125,7 @@ async function postForm<T>(
 export async function getNoteById(
   id: string,
   authToken: string,
-): Promise<Note> {
+): Promise<PopulatedNote> {
   return get(`/api/notes/${id}`, authToken);
 }
 
@@ -134,7 +136,7 @@ export async function deleteNoteById(
   return del(`/api/notes/${id}`, authToken);
 }
 
-export async function getNotes(authToken: string): Promise<Note[]> {
+export async function getNotes(authToken: string): Promise<PopulatedNote[]> {
   return get("/api/notes", authToken);
 }
 

--- a/apps/nextjs/src/app/api/digest/route.ts
+++ b/apps/nextjs/src/app/api/digest/route.ts
@@ -61,13 +61,22 @@ export async function POST(req: NextRequest) {
     data: {
       id: noteId,
       owner: userId,
-      title,
-      content,
       digestSpan: span,
       digestStartDate: startDate.toISO()!,
       parents: {
         connect: notes.map((note) => ({ id: note.id })),
       },
+      activeRevision: {
+        create: {
+          id: generateId("noteRevision"),
+          noteId,
+          title,
+          content,
+        },
+      },
+    },
+    include: {
+      activeRevision: true,
     },
   });
   return Response.json(note);

--- a/apps/nextjs/src/app/api/digest/route.ts
+++ b/apps/nextjs/src/app/api/digest/route.ts
@@ -66,7 +66,7 @@ export async function POST(req: NextRequest) {
       parents: {
         connect: notes.map((note) => ({ id: note.id })),
       },
-      activeRevision: {
+      revision: {
         create: {
           id: generateId("noteRevision"),
           noteId,
@@ -76,7 +76,7 @@ export async function POST(req: NextRequest) {
       },
     },
     include: {
-      activeRevision: true,
+      revision: true,
     },
   });
   return Response.json(note);

--- a/apps/nextjs/src/app/api/notes/[id]/route.ts
+++ b/apps/nextjs/src/app/api/notes/[id]/route.ts
@@ -1,9 +1,8 @@
 import type { NextApiRequest } from "next";
-import { NextRequest } from "next/server";
 import { auth } from "@clerk/nextjs";
 import { z } from "zod";
 
-import { prisma } from "@brain2/db";
+import { generateId, prisma } from "@brain2/db";
 
 const getNoteSchema = z.object({
   id: z.string(),
@@ -74,9 +73,18 @@ export async function PATCH(
     where: { id, owner: userId },
   });
 
+  const revision = await prisma.noteRevision.create({
+    data: {
+      id: generateId("noteRevision"),
+      noteId: id,
+      title,
+      content,
+    },
+  });
+
   const updatedNote = await prisma.note.update({
-    where: { id, owner: userId },
-    data: { title, content },
+    where: { id },
+    data: { activeRevisionId: revision.id },
   });
 
   return Response.json(updatedNote);

--- a/apps/nextjs/src/app/api/notes/[id]/route.ts
+++ b/apps/nextjs/src/app/api/notes/[id]/route.ts
@@ -24,6 +24,7 @@ export async function GET(
   const { id } = getNoteSchema.parse(params);
   const note = await prisma.note.findUniqueOrThrow({
     where: { id, owner: userId },
+    include: { revision: true },
   });
   return Response.json(note);
 }

--- a/apps/nextjs/src/app/api/notes/[id]/route.ts
+++ b/apps/nextjs/src/app/api/notes/[id]/route.ts
@@ -84,7 +84,8 @@ export async function PATCH(
 
   const updatedNote = await prisma.note.update({
     where: { id },
-    data: { activeRevisionId: revision.id },
+    data: { revisionId: revision.id },
+    include: { revision: true },
   });
 
   return Response.json(updatedNote);

--- a/apps/nextjs/src/app/api/notes/route.ts
+++ b/apps/nextjs/src/app/api/notes/route.ts
@@ -52,7 +52,7 @@ export async function POST(req: Request): Promise<Response> {
       id: noteId,
       owner: userId,
       digestSpan: "SINGLE",
-      activeRevision: {
+      revision: {
         create: {
           id: generateId("noteRevision"),
           noteId,
@@ -62,7 +62,7 @@ export async function POST(req: Request): Promise<Response> {
       },
     },
     include: {
-      activeRevision: true,
+      revision: true,
     },
   });
   return Response.json(note);

--- a/apps/nextjs/src/app/api/notes/route.ts
+++ b/apps/nextjs/src/app/api/notes/route.ts
@@ -22,6 +22,9 @@ export async function GET(_req: Request): Promise<Response> {
     orderBy: {
       digestStartDate: "desc",
     },
+    include: {
+      revision: true,
+    },
   });
   return Response.json(notes);
 }

--- a/apps/nextjs/src/app/api/notes/route.ts
+++ b/apps/nextjs/src/app/api/notes/route.ts
@@ -46,13 +46,23 @@ export async function POST(req: Request): Promise<Response> {
   const formattedDate = DateTime.now().toFormat("dd/MM/yyyy HH:mm:ss");
   const fallbackTitle = `New Note ${formattedDate}`;
 
+  const noteId = generateId("note");
   const note = await prisma.note.create({
     data: {
-      id: generateId("note"),
-      title: title ?? fallbackTitle,
-      content,
+      id: noteId,
       owner: userId,
       digestSpan: "SINGLE",
+      activeRevision: {
+        create: {
+          id: generateId("noteRevision"),
+          noteId,
+          title: title ?? fallbackTitle,
+          content,
+        },
+      },
+    },
+    include: {
+      activeRevision: true,
     },
   });
   return Response.json(note);

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -2,7 +2,6 @@
   "name": "@brain2/db",
   "version": "1.0.0",
   "license": "MIT",
-  "type": "module",
   "exports": {
     ".": "./src/index.ts",
     "./edge": "./src/edge.ts"
@@ -21,7 +20,8 @@
     "prebuild": "npm run generate",
     "predev": "npm run generate",
     "studio": "prisma studio",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "with-env": "dotenv -e ../../.env --"
   },
   "dependencies": {
     "@paralleldrive/cuid2": "^2.2.2",

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -51,10 +51,6 @@ model Note {
   id    String @id @map("_id")
   owner String //userId
 
-  // Deprecated
-  title   String?
-  content String?
-
   // Current active revision
   revisionId String?       @unique
   revision   NoteRevision? @relation(name: "activeRevision", fields: [revisionId], references: [id])

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -3,8 +3,8 @@ generator client {
 }
 
 datasource db {
-  provider = "mongodb"
-  url      = env("DATABASE_URL")
+  provider  = "mongodb"
+  url       = env("DATABASE_URL")
   directUrl = env("MONGO_URL")
 }
 
@@ -51,8 +51,16 @@ model Note {
   id    String @id @map("_id")
   owner String //userId
 
-  title      String
-  content    String
+  // Deprecated
+  title   String?
+  content String?
+
+  // Current active revision
+  activeRevisionId String?       @unique
+  activeRevision   NoteRevision? @relation(name: "activeRevision", fields: [activeRevisionId], references: [id])
+
+  revisions NoteRevision[] @relation(name: "noteRevisions")
+
   digestSpan NoteDigestSpan
   recording  AudioBlob?
 
@@ -68,6 +76,20 @@ model Note {
   active          Boolean  @default(true)
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
+}
+
+model NoteRevision {
+  id     String @id @map("_id")
+  noteId String
+  note   Note   @relation(name: "noteRevisions", fields: [noteId], references: [id], onUpdate: NoAction)
+
+  activeNote Note? @relation(name: "activeRevision")
+
+  title   String
+  content String
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }
 
 // Represents the span of a note digest

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -56,8 +56,8 @@ model Note {
   content String?
 
   // Current active revision
-  activeRevisionId String?       @unique
-  activeRevision   NoteRevision? @relation(name: "activeRevision", fields: [activeRevisionId], references: [id])
+  revisionId String?       @unique
+  revision   NoteRevision? @relation(name: "activeRevision", fields: [revisionId], references: [id])
 
   revisions NoteRevision[] @relation(name: "noteRevisions")
 

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -86,6 +86,8 @@ model NoteRevision {
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  @@index([noteId])
 }
 
 // Represents the span of a note digest

--- a/packages/db/src/generateId.ts
+++ b/packages/db/src/generateId.ts
@@ -16,6 +16,7 @@ const prefixes: Record<PrismaModelName, string> = {
   note: "note",
   chatConversation: "conv",
   messengerUser: "messenger_user",
+  noteRevision: "ntrv",
 };
 
 /**

--- a/packages/lib/src/queue/functions/batchDigest/handler.ts
+++ b/packages/lib/src/queue/functions/batchDigest/handler.ts
@@ -76,7 +76,7 @@ export const handler = inngestEdgeClient.createFunction(
           parents: {
             connect: notes.map((note) => ({ id: note.id })),
           },
-          activeRevision: {
+          revision: {
             create: {
               id: generateId("noteRevision"),
               noteId,

--- a/packages/lib/src/queue/functions/batchDigest/handler.ts
+++ b/packages/lib/src/queue/functions/batchDigest/handler.ts
@@ -71,12 +71,18 @@ export const handler = inngestEdgeClient.createFunction(
         data: {
           id: noteId,
           owner: owner,
-          title,
-          content,
           digestSpan: span,
           digestStartDate: startDate.toISO()!,
           parents: {
             connect: notes.map((note) => ({ id: note.id })),
+          },
+          activeRevision: {
+            create: {
+              id: generateId("noteRevision"),
+              noteId,
+              title,
+              content,
+            },
           },
         },
       });

--- a/packages/migrations/package.json
+++ b/packages/migrations/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@brain2/migrations",
+  "private": true,
+  "version": "0.1.0",
+  "license": "MIT",
+  "scripts": {
+    "migrate": "pnpm with-env ts-node src/index.ts",
+    "clean": "rm -rf .turbo node_modules",
+    "lint": "eslint .",
+    "format": "prettier --check . --ignore-path ../../.gitignore",
+    "typecheck": "tsc --noEmit",
+    "with-env": "dotenv -e ../../.env --"
+  },
+  "devDependencies": {
+    "@brain2/eslint-config": "workspace:^0.2.0",
+    "@brain2/prettier-config": "workspace:^0.1.0",
+    "@brain2/tsconfig": "workspace:^0.1.0",
+    "eslint": "^8.56.0",
+    "prettier": "^3.1.1",
+    "typescript": "^5.3.3"
+  },
+  "eslintConfig": {
+    "extends": [
+      "@brain2/eslint-config/base"
+    ]
+  },
+  "prettier": "@brain2/prettier-config"
+}

--- a/packages/migrations/src/index.ts
+++ b/packages/migrations/src/index.ts
@@ -1,0 +1,10 @@
+import migrateNoteRevision from "./migrations/migrateNoteRevision";
+
+/**
+ * Run a migration
+ */
+export default async function main() {
+  await migrateNoteRevision();
+}
+
+void main();

--- a/packages/migrations/src/migrations/migrateNoteRevision.ts
+++ b/packages/migrations/src/migrations/migrateNoteRevision.ts
@@ -24,7 +24,7 @@ export default async function migrateNoteRevision() {
           id: revision.noteId,
         },
         data: {
-          activeRevisionId: revision.id,
+          revisionId: revision.id,
         },
       }),
     ),

--- a/packages/migrations/src/migrations/migrateNoteRevision.ts
+++ b/packages/migrations/src/migrations/migrateNoteRevision.ts
@@ -1,0 +1,32 @@
+import { generateId, prisma } from "@brain2/db";
+
+/**
+ * Create note revisions for each note and delete their contents
+ */
+export default async function migrateNoteRevision() {
+  // Create revisions
+  const notes = await prisma.note.findMany();
+  await prisma.noteRevision.createMany({
+    data: notes.map((note) => ({
+      id: generateId("noteRevision"),
+      noteId: note.id,
+      title: note.title!,
+      content: note.content!,
+    })),
+  });
+
+  // Update active revision
+  const noteRevisions = await prisma.noteRevision.findMany();
+  await prisma.$transaction(
+    noteRevisions.map((revision) =>
+      prisma.note.update({
+        where: {
+          id: revision.noteId,
+        },
+        data: {
+          activeRevisionId: revision.id,
+        },
+      }),
+    ),
+  );
+}

--- a/packages/migrations/tsconfig.json
+++ b/packages/migrations/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./node_modules/@brain2/tsconfig/node.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json",
+    "paths": {
+      "@brain2/db/*": ["../db/src/*"],
+    },
+  },
+  "include": ["*.ts", "src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -452,6 +452,27 @@ importers:
         specifier: ^5.3.3
         version: 5.3.3
 
+  packages/migrations:
+    devDependencies:
+      '@brain2/eslint-config':
+        specifier: workspace:^0.2.0
+        version: link:../../tooling/eslint
+      '@brain2/prettier-config':
+        specifier: workspace:^0.1.0
+        version: link:../../tooling/prettier
+      '@brain2/tsconfig':
+        specifier: workspace:^0.1.0
+        version: link:../../tooling/typescript
+      eslint:
+        specifier: ^8.56.0
+        version: 8.56.0
+      prettier:
+        specifier: ^3.1.1
+        version: 3.1.1
+      typescript:
+        specifier: ^5.3.3
+        version: 5.3.3
+
   tooling/eslint:
     dependencies:
       '@next/eslint-plugin-next':
@@ -3421,7 +3442,7 @@ packages:
     dependencies:
       '@jridgewell/set-array': 1.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
-      '@jridgewell/trace-mapping': 0.3.18
+      '@jridgewell/trace-mapping': 0.3.22
 
   /@jridgewell/resolve-uri@3.1.0:
     resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==}
@@ -3435,7 +3456,7 @@ packages:
     resolution: {integrity: sha512-b+fsZXeLYi9fEULmfBrhxn4IrPlINf8fiNarzTof004v3lFdntdwa9PF7vFJqm3mg7s+ScJMxXaE3Acp1irZcg==}
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
-      '@jridgewell/trace-mapping': 0.3.18
+      '@jridgewell/trace-mapping': 0.3.22
     dev: false
 
   /@jridgewell/sourcemap-codec@1.4.14:
@@ -3455,7 +3476,6 @@ packages:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.0
       '@jridgewell/sourcemap-codec': 1.4.15
-    dev: false
 
   /@jridgewell/trace-mapping@0.3.9:
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
@@ -6052,6 +6072,7 @@ packages:
   /acorn@8.11.2:
     resolution: {integrity: sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==}
     engines: {node: '>=0.4.0'}
+    hasBin: true
 
   /adm-zip@0.5.10:
     resolution: {integrity: sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==}


### PR DESCRIPTION
This modifies the schema to add support for note version history. Rather than the note models themselves containing the `title` and `content`, this will instead point to a `NoteRevision` which contains those specific parameters. Whenever a note is created or modified, it creates a new note revision and points the note to that revision. This way, we can support version history. If storage becomes an issue, we can look into defining some sort of TTL for these revisions.